### PR TITLE
MISC: Unnecessary composer requirement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
   },
   "require": {
     "silverstripe/vendor-plugin": "^1.0",
-    "silverstripe/framework": "^4",
-    "silverstripe/cms": "^4"
+    "silverstripe/framework": "^4"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
SilverStripe CMS is no longer required as all dependencies are satisfied by the SilverStripe framework.