### PR TITLE
Prevent error with reset button. Fix compatibility issue for ss4.8

### DIFF
--- a/src/Form/GridField/RichFilterHeader.php
+++ b/src/Form/GridField/RichFilterHeader.php
@@ -571,7 +571,7 @@ class RichFilterHeader extends GridFieldFilterHeader
                 }
             }
         } elseif ($actionName === 'reset') {
-            $state->Columns = null;
+            $state->Columns = new GridState_Data([]);
 
             // reset all custom fields
             foreach ($this->filter_fields as $field) {

--- a/src/Form/GridField/RichFilterHeader.php
+++ b/src/Form/GridField/RichFilterHeader.php
@@ -571,7 +571,11 @@ class RichFilterHeader extends GridFieldFilterHeader
                 }
             }
         } elseif ($actionName === 'reset') {
-            $state->Columns = new GridState_Data([]);
+            if( $state->Columns instanceof GridState_Data ) {
+                $state->Columns = new GridState_Data([]);
+            } else {
+                $state->Columns = [];
+            }
 
             // reset all custom fields
             foreach ($this->filter_fields as $field) {


### PR DESCRIPTION
At least for SS4.8 $stage->Columns needs to be instance of GridState_Data or reset won't work and will throw server error. Fix initialises variable as new empty GridState_Data.